### PR TITLE
Updated to be compatible with the latest version of simplecov

### DIFF
--- a/lib/simplecov-teamcity-summary/formatter.rb
+++ b/lib/simplecov-teamcity-summary/formatter.rb
@@ -1,4 +1,9 @@
-module Simplecov::Formatter
+# Ensure we are using a compatible version of SimpleCov
+if Gem::Version.new(SimpleCov::VERSION) < Gem::Version.new("0.8.0")
+  raise RuntimeError, 'The version of SimpleCov you are using is too old. Please update with `gem install simplecov` or `bundle update simplecov`'
+end
+
+module SimpleCov::Formatter
   class TeamcitySummaryFormatter
     def format(simplecov_results)
       puts format_teamcity(simplecov_results)

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Simplecov::Formatter::TeamcitySummaryFormatter do
+describe SimpleCov::Formatter::TeamcitySummaryFormatter do
   describe "#format" do
     before do 
       expect_any_instance_of(described_class).to receive(:format_teamcity).with(:arg).and_return(:return_value)


### PR DESCRIPTION
For some reason the namespace name has changed from `Simplecov` to `SimpleCov`
