### PR TITLE
Require simplecov

### DIFF
--- a/lib/simplecov-teamcity-summary/formatter.rb
+++ b/lib/simplecov-teamcity-summary/formatter.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+
 # Ensure we are using a compatible version of SimpleCov
 if Gem::Version.new(SimpleCov::VERSION) < Gem::Version.new("0.8.0")
   raise RuntimeError, 'The version of SimpleCov you are using is too old. Please update with `gem install simplecov` or `bundle update simplecov`'


### PR DESCRIPTION
Explicitly require simplecov.

If we don't this, we will get uninitialized constant errors if we install simplecov with the default instructions of setting `require: false`

See issue https://github.com/benc/simplecov-teamcity-summary/issues/4