### PR TITLE
Remove CodeCoverageL

### DIFF
--- a/lib/simplecov-teamcity-summary/formatter.rb
+++ b/lib/simplecov-teamcity-summary/formatter.rb
@@ -15,7 +15,6 @@ module SimpleCov::Formatter
       <<-eos
 
 ##teamcity[blockOpened name='Code Coverage Summary']
-##teamcity[buildStatisticValue key='CodeCoverageL' value='#{simplecov_results.covered_percent}']
 ##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='#{simplecov_results.covered_lines}']
 ##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='#{simplecov_results.total_lines}']
 ##teamcity[blockClosed name='Code Coverage Summary']


### PR DESCRIPTION
Per TeamCity [documentation](https://confluence.jetbrains.com/pages/viewpage.action?pageId=74845225#HowTo...-ImportcoverageresultsinTeamCity), "You should not publish values CodeCoverageB, CodeCoverageL, CodeCoverageM, CodeCoverageC standing for block/line/method/class coverage percentage. TeamCity will calculate these values using their absolute parts."